### PR TITLE
[breaking change] rebrand to G14Manager

### DIFF
--- a/.github/build.ps1
+++ b/.github/build.ps1
@@ -19,7 +19,7 @@ Invoke-Expression $CommandInstallRSRC
 # easier for us to debug
 Get-ChildItem $GOBIN
 
-$RSRC = $GOBIN + "\rsrc.exe -arch amd64 -manifest ROGManager.exe.manifest -ico go.ico -o ROGManager.exe.syso"
+$RSRC = $GOBIN + "\rsrc.exe -arch amd64 -manifest G14Manager.exe.manifest -ico go.ico -o G14Manager.exe.syso"
 Invoke-Expression $RSRC
 
 # Stupid go mod download writes to stderr
@@ -29,10 +29,10 @@ Invoke-Expression $MOD 2>&1
 Write-Host "Building prod release"
 
 # $BUILD = "go build -tags 'use_cgo' -ldflags='-H=windowsgui -s -w' ."
-$BUILD = "go build -ldflags=`"-H=windowsgui -s -w -X 'main.Version=$env:GITHUB_REF'`" -o build/ROGManager.exe ."
+$BUILD = "go build -ldflags=`"-H=windowsgui -s -w -X 'main.Version=$env:GITHUB_REF'`" -o build/G14Manager.exe ."
 Invoke-Expression $BUILD
 
 Write-Host "Building debug release"
 
-$BUILD_DEBUG = "go build -ldflags=`"-X 'main.Version=$env:GITHUB_REF'`" -o build/ROGManager.debug.exe ."
+$BUILD_DEBUG = "go build -ldflags=`"-X 'main.Version=$env:GITHUB_REF'`" -o build/G14Manager.debug.exe ."
 Invoke-Expression $BUILD_DEBUG

--- a/G14Manager.exe.manifest
+++ b/G14Manager.exe.manifest
@@ -3,7 +3,7 @@
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="amd64"
-    name="ROGManager"
+    name="G14Manager"
     type="win32"
 />
 <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ROGManager: An open source replacement to manage your G14
+# G14Manager: An open source replacement to manage your G14
 
-![Test and Build](https://github.com/zllovesuki/ROGManager/workflows/Test%20and%20Build/badge.svg) ![Build Release](https://github.com/zllovesuki/ROGManager/workflows/Build%20Release/badge.svg)
+![Test and Build](https://github.com/zllovesuki/G14Manager/workflows/Test%20and%20Build/badge.svg) ![Build Release](https://github.com/zllovesuki/G14Manager/workflows/Build%20Release/badge.svg)
 
 ## Disclaimer
 
@@ -8,34 +8,34 @@ Your warranty is now void. Proceed at your own risk.
 
 ## Current Status
 
-Follow project status on [Sprint Board](https://github.com/zllovesuki/ROGManager/projects/1). This will include features in progress.
+Follow project status on [Sprint Board](https://github.com/zllovesuki/G14Manager/projects/1). This will include features in progress.
 
-After some reverse engineering, ROGManager now (mostly) replaces Asus software suite's functionalities. Unimplemented functionalities are:
+After some reverse engineering, G14Manager now (mostly) replaces Asus software suite's functionalities. Unimplemented functionalities are:
 1. ~~Toggle mute/unmute microphone~~
 2. ~~Toggle enable/disable TouchPad~~
 3. ~~Keyboard brightness adjustment~~
 4. On-screen display
 5. AniMe Matrix control
 
-_Note_: Currently, the default profiles expect Power Plans "High Performance" and "Power Saver" to be available. If your installation of Windows does not have those Power Plans, ROGManager will refuse to start. This will be fixed when customizable config is released.
+_Note_: Currently, the default profiles expect Power Plans "High Performance" and "Power Saver" to be available. If your installation of Windows does not have those Power Plans, G14Manager will refuse to start. This will be fixed when customizable config is released.
 
 ## Bug Report
 
-If your encounter an issue with using ROGManager (e.g. does not start, functionalities not working, etc), please download the debug build `ROGManager.debug.exe`, and run the binary in a Terminal with Administrator Privileges, then submit an issue with the full logs.
+If your encounter an issue with using G14Manager (e.g. does not start, functionalities not working, etc), please download the debug build `G14Manager.debug.exe`, and run the binary in a Terminal with Administrator Privileges, then submit an issue with the full logs.
 
 ## Requirements
 
-You must have a Zephyrus G14 (GA401), and has Asus Optimization the driver (aka Asus System Control Interface V2) installed. You may check and see if `C:\Windows\System32\DriverStore\FileRepository\asussci2.inf_amd64_xxxxxxxxxxxxxxxx` exists. ROGManager is **not tested** on other Zephyrus laptops (e.g. G15). You are welcome to test ROGManager on laptops such as G15, however support will be limited, and all functionalities are not guaranteed to be working.
+You must have a Zephyrus G14 (GA401), and has Asus Optimization the driver (aka Asus System Control Interface V2) installed. You may check and see if `C:\Windows\System32\DriverStore\FileRepository\asussci2.inf_amd64_xxxxxxxxxxxxxxxx` exists. G14Manager is **not tested** on other Zephyrus laptops (e.g. G15). You are welcome to test G14Manager on laptops such as G15, however support will be limited, and all functionalities are not guaranteed to be working.
 
-Asus Optimization (the service) **cannot** be running, otherwise ROGManager and Asus Optimization will be fighting over control. We only need Asus Optimization (the driver) to be installed so Windows will load `atkwmiacpi64.sys`, and exposes a `\\.\ATKACPI` device to be used.
+Asus Optimization (the service) **cannot** be running, otherwise G14Manager and Asus Optimization will be fighting over control. We only need Asus Optimization (the driver) to be installed so Windows will load `atkwmiacpi64.sys`, and exposes a `\\.\ATKACPI` device to be used.
 
-You do not need any other softwares from Asus (e.g. Armoury Crate and its cousins, etc) running to use ROGManager; you can safely uninstall them from your system. However, some softwares (e.g. Asus Optimization) are installed as Windows Services, and you should disable them in Services as they do not provide any value:
+You do not need any other softwares from Asus (e.g. Armoury Crate and its cousins, etc) running to use G14Manager; you can safely uninstall them from your system. However, some softwares (e.g. Asus Optimization) are installed as Windows Services, and you should disable them in Services as they do not provide any value:
 
 ![Running Services](images/services.png)
 
 Optionally, disable ASUS System Analysis Driver with `sc.exe config "ASUSSAIO" start=disabled` in a Terminal with Administrator privileges, if you do not plan to use MyASUS.
 
-Recommend running `ROGManager.exe` on startup in Task Scheduler with "Run with highest privileges."
+Recommend running `G14Manager.exe` on startup in Task Scheduler with "Run with highest privileges."
 
 ## Remapping Fn+Left/Right to PgUp/PgDown
 
@@ -54,14 +54,14 @@ By default, it will launch Task Manager when you press the ROG Key once.
 To specify which program to launch when pressed multiple times, pass your path to the desired program as argument to `-rog` multiple times. For example:
 
 ```
-.\ROGManager.exe -rog "Taskmgr.exe" -rog "start Spotify.exe"
+.\G14Manager.exe -rog "Taskmgr.exe" -rog "start Spotify.exe"
 ```
 
 This will launch Task Manager when you press the ROG key once, and Spotify when you press twice.
 
 ## Changing the Fan Curve
 
-For the initial release, you have to change fan curve in `system\thermal\default.go`. In a future release ROGManager will allow you to specify the fan curve without rebuilding the binary. However, the default fan curve should be sufficient for most users.
+For the initial release, you have to change fan curve in `system\thermal\default.go`. In a future release G14Manager will allow you to specify the fan curve without rebuilding the binary. However, the default fan curve should be sufficient for most users.
 
 Use the `Fn + F5` key combo to cycle through all the profiles. Fanless -> Quiet -> Slient -> Performance.
 
@@ -72,7 +72,7 @@ The key combo has a time delay. If you press the combo X times, it will apply th
 1. Install golang 1.14+ if you don't have it already
 2. Install mingw x86_64 for `gcc.exe`
 2. Install `rsrc`: `go get github.com/akavel/rsrc`
-3. Generate `syso` file: `\path\to\rsrc.exe -arch amd64 -manifest ROGManager.exe.manifest -ico go.ico -o ROGManager.exe.syso`
+3. Generate `syso` file: `\path\to\rsrc.exe -arch amd64 -manifest G14Manager.exe.manifest -ico go.ico -o G14Manager.exe.syso`
 4. Build the binary: `.\scripts\build.ps1`
 
 ## Developing
@@ -87,4 +87,4 @@ Most keycodes can be found in [reverse_eng/codes.txt](reverse_eng/codes.txt), an
 - https://github.com/torvalds/linux/blob/master/drivers/platform/x86/asus-nb-wmi.c
 - https://github.com/torvalds/linux/blob/master/drivers/hid/hid-asus.c
 - https://github.com/flukejones/rog-core/blob/master/kernel-patch/0001-HID-asus-add-support-for-ASUS-N-Key-keyboard-v5.8.patch
-- [Reverse Engineering](./reverse_eng.md)
+- [Reverse Engineering](./reverse_eng)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -9,19 +9,19 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/zllovesuki/ROGManager/system/atkacpi"
-	"github.com/zllovesuki/ROGManager/system/ioctl"
-	"github.com/zllovesuki/ROGManager/system/keyboard"
-	"github.com/zllovesuki/ROGManager/system/persist"
-	"github.com/zllovesuki/ROGManager/system/thermal"
-	"github.com/zllovesuki/ROGManager/system/volume"
-	"github.com/zllovesuki/ROGManager/util"
+	"github.com/zllovesuki/G14Manager/system/atkacpi"
+	"github.com/zllovesuki/G14Manager/system/ioctl"
+	"github.com/zllovesuki/G14Manager/system/keyboard"
+	"github.com/zllovesuki/G14Manager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/thermal"
+	"github.com/zllovesuki/G14Manager/system/volume"
+	"github.com/zllovesuki/G14Manager/util"
 
 	"gopkg.in/toast.v1"
 )
 
 const (
-	appName = "ROGManager"
+	appName = "G14Manager"
 )
 
 type Controller interface {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zllovesuki/ROGManager
+module github.com/zllovesuki/G14Manager
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -9,14 +9,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/zllovesuki/ROGManager/system/keyboard"
-	"github.com/zllovesuki/ROGManager/system/volume"
+	"github.com/zllovesuki/G14Manager/system/keyboard"
+	"github.com/zllovesuki/G14Manager/system/volume"
 
-	"github.com/zllovesuki/ROGManager/controller"
-	"github.com/zllovesuki/ROGManager/system/battery"
-	"github.com/zllovesuki/ROGManager/system/persist"
-	"github.com/zllovesuki/ROGManager/system/thermal"
-	"github.com/zllovesuki/ROGManager/util"
+	"github.com/zllovesuki/G14Manager/controller"
+	"github.com/zllovesuki/G14Manager/system/battery"
+	"github.com/zllovesuki/G14Manager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/thermal"
+	"github.com/zllovesuki/G14Manager/util"
 )
 
 var (
@@ -34,7 +34,7 @@ func main() {
 
 	flag.Parse()
 
-	log.Printf("ROGManager version: %s\n", Version)
+	log.Printf("G14Manager version: %s\n", Version)
 	log.Printf("Experimental enabled: %v\n", *enableExperimental)
 
 	if len(rogRemap) == 0 {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -7,7 +7,7 @@ $env:GOOS = "windows"
 $env:GOARCH = "amd64"
 $env:CDO_ENABLED = 1
 
-rsrc.exe -arch amd64 -manifest ROGManager.exe.manifest -ico go.ico -o ROGManager.exe.syso
+rsrc.exe -arch amd64 -manifest G14Manager.exe.manifest -ico go.ico -o G14Manager.exe.syso
 
-go build -ldflags="-H=windowsgui -s -w" -o "build/ROGManager.exe" .
-go build -o "build/ROGManager.debug.exe" .
+go build -ldflags="-H=windowsgui -s -w" -o "build/G14Manager.exe" .
+go build -o "build/G14Manager.debug.exe" .

--- a/system/atkacpi/atkacpi.go
+++ b/system/atkacpi/atkacpi.go
@@ -1,7 +1,7 @@
 package atkacpi
 
 import (
-	"github.com/zllovesuki/ROGManager/system/device"
+	"github.com/zllovesuki/G14Manager/system/device"
 )
 
 // Defines the byte index for setting behavior

--- a/system/battery/battery.go
+++ b/system/battery/battery.go
@@ -4,9 +4,9 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/zllovesuki/ROGManager/system/atkacpi"
-	"github.com/zllovesuki/ROGManager/system/ioctl"
-	"github.com/zllovesuki/ROGManager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/atkacpi"
+	"github.com/zllovesuki/G14Manager/system/ioctl"
+	"github.com/zllovesuki/G14Manager/system/persist"
 )
 
 const (

--- a/system/keyboard/control.go
+++ b/system/keyboard/control.go
@@ -21,9 +21,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/zllovesuki/ROGManager/system/device"
-	"github.com/zllovesuki/ROGManager/system/ioctl"
-	"github.com/zllovesuki/ROGManager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/device"
+	"github.com/zllovesuki/G14Manager/system/ioctl"
+	"github.com/zllovesuki/G14Manager/system/persist"
 
 	"github.com/karalabe/usb"
 )

--- a/system/persist/helper.go
+++ b/system/persist/helper.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	registryKey  = registry.LOCAL_MACHINE
-	registryPath = `SOFTWARE\ROGManager`
+	registryPath = `SOFTWARE\G14Manager`
 )
 
 // RegistryHelper contains a list of configurations to be loaded, saved, and applied

--- a/system/thermal/powercfg.go
+++ b/system/thermal/powercfg.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/zllovesuki/ROGManager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/persist"
 )
 
 const (

--- a/system/thermal/thermal.go
+++ b/system/thermal/thermal.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"log"
 
-	"github.com/zllovesuki/ROGManager/system/atkacpi"
-	"github.com/zllovesuki/ROGManager/system/ioctl"
-	"github.com/zllovesuki/ROGManager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/atkacpi"
+	"github.com/zllovesuki/G14Manager/system/ioctl"
+	"github.com/zllovesuki/G14Manager/system/persist"
 )
 
 const (


### PR DESCRIPTION
Rename all references to "ROGManager" to be "G14Manager". Fix #31 