### PR TITLE
bugfix: reapply configs on resume

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zllovesuki/G14Manager/system/battery"
 	"github.com/zllovesuki/G14Manager/system/keyboard"
 	"github.com/zllovesuki/G14Manager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/power"
 	"github.com/zllovesuki/G14Manager/system/thermal"
 	"github.com/zllovesuki/G14Manager/system/volume"
 	"github.com/zllovesuki/G14Manager/util"
@@ -45,7 +46,7 @@ func main() {
 
 	config, _ := persist.NewRegistryHelper()
 
-	powercfg, err := thermal.NewPowerCfg()
+	powercfg, err := power.NewCfg()
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/system/device/device.go
+++ b/system/device/device.go
@@ -44,12 +44,12 @@ func NewControl(path string, controlCode uint32) (*Control, error) {
 
 func (d *Control) Write(input []byte) (int, error) {
 	if d.isDryRun {
-		log.Printf("[dry run] device: %s (%d) write input buffer [0:16]: %+v\n", d.path, d.controlCode, input[0:16])
+		log.Printf("[dry run] device: %s (%d) write input buffer [0:8]: %+v\n", d.path, d.controlCode, input[0:8])
 		return len(input), nil
 	}
 	outBuf := make([]byte, 1024)
 	outBufWritten := uint32(0)
-	log.Printf("device: %s (%d) write input buffer [0:16]: %+v\n", d.path, d.controlCode, input[0:16])
+	log.Printf("device: %s (%d) write input buffer [0:8]: %+v\n", d.path, d.controlCode, input[0:8])
 	err := windows.DeviceIoControl(
 		d.handle,
 		d.controlCode,
@@ -63,17 +63,17 @@ func (d *Control) Write(input []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	log.Printf("device: write output buffer [0:16]: %+v\n", outBuf[0:16])
+	log.Printf("device: write output buffer [0:8]: %+v\n", outBuf[0:8])
 	return len(input), nil
 }
 
 func (d *Control) Read(outBuf []byte) (int, error) {
 	if d.isDryRun {
-		log.Printf("[dry run] device: %s (%d) read input buffer [0:16]: %+v\n", d.path, d.controlCode, outBuf[0:16])
+		log.Printf("[dry run] device: %s (%d) read input buffer [0:8]: %+v\n", d.path, d.controlCode, outBuf[0:8])
 		return 0, nil
 	}
 	outBufWritten := uint32(0)
-	log.Printf("device: %s (%d) read input buffer [0:16]: %+v\n", d.path, d.controlCode, outBuf[0:16])
+	log.Printf("device: %s (%d) read input buffer [0:8]: %+v\n", d.path, d.controlCode, outBuf[0:8])
 	err := windows.DeviceIoControl(
 		d.handle,
 		d.controlCode,
@@ -92,7 +92,7 @@ func (d *Control) Read(outBuf []byte) (int, error) {
 
 func (d *Control) Execute(input []byte, outLen int) ([]byte, error) {
 	if d.isDryRun {
-		log.Printf("[dry run] device: %s (%d) execute input buffer [0:16]: %+v\n", d.path, d.controlCode, input[0:16])
+		log.Printf("[dry run] device: %s (%d) execute input buffer [0:8]: %+v\n", d.path, d.controlCode, input[0:8])
 		return make([]byte, outLen), nil
 	}
 	outBuf := make([]byte, 1024)

--- a/system/keyboard/control.go
+++ b/system/keyboard/control.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log"
-	"runtime"
 	"strings"
 
 	"github.com/zllovesuki/G14Manager/system/device"
@@ -155,7 +154,8 @@ func NewControl() (*Control, error) {
 	}, nil
 }
 
-func (c *Control) setBrightness(v Level) error {
+// SetBrightness sets the keyboard backlight brightness to an arbitary level
+func (c *Control) SetBrightness(v Level) error {
 	inputBuf := make([]byte, brightnessControlBufferLength)
 	copy(inputBuf, brightnessControlBuffer)
 	inputBuf[brightnessControlByteIndex] = byte(v)
@@ -170,7 +170,7 @@ func (c *Control) setBrightness(v Level) error {
 	return nil
 }
 
-// BrightnessUp increases the keyboard brightness by one level
+// BrightnessUp increases the keyboard backlight brightness by one level
 // TODO: use a FSM
 func (c *Control) BrightnessUp() error {
 	var targetLevel Level
@@ -184,10 +184,10 @@ func (c *Control) BrightnessUp() error {
 	default:
 		return nil
 	}
-	return c.setBrightness(targetLevel)
+	return c.SetBrightness(targetLevel)
 }
 
-// BrightnessDown decreases the keyboard brightness by one level
+// BrightnessDown decreases the keyboard backlight brightness by one level
 // TODO: use a FSM
 func (c *Control) BrightnessDown() error {
 	var targetLevel Level
@@ -201,7 +201,7 @@ func (c *Control) BrightnessDown() error {
 	default:
 		return nil
 	}
-	return c.setBrightness(targetLevel)
+	return c.SetBrightness(targetLevel)
 }
 
 // ToggleTouchPad will toggle between disabling/enabling TouchPad
@@ -221,9 +221,6 @@ func (c *Control) ToggleTouchPad() error {
 
 // EmulateKeyPress allows you send arbitary keyboard scan code. Useful for remapping Fn + <key>
 func (c *Control) EmulateKeyPress(keyCode uint16) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	if C.send_key_press(C.ushort(keyCode)) != 0 {
 		return fmt.Errorf("kbCtrl: cannot emulate key press")
 	}
@@ -270,7 +267,7 @@ func (c *Control) Load(v []byte) error {
 
 // Apply satisfies persist.Registry
 func (c *Control) Apply() error {
-	return c.setBrightness(c.currentBrightness)
+	return c.SetBrightness(c.currentBrightness)
 }
 
 // Close satisfied persist.Registry

--- a/system/power/event.go
+++ b/system/power/event.go
@@ -1,0 +1,52 @@
+package power
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// adapted from https://golang.org/src/runtime/os_windows.go
+
+var (
+	libPowrProf                            = windows.NewLazySystemDLL("powrprof.dll")
+	powerRegisterSuspendResumeNotification = libPowrProf.NewProc("PowerRegisterSuspendResumeNotification")
+)
+
+// Defines the type of event
+const (
+	PBT_APMSUSPEND         uint32 = 4
+	PBT_APMRESUMESUSPEND   uint32 = 7
+	PBT_APMRESUMEAUTOMATIC uint32 = 18
+)
+
+// NewEventListener will listen for PowerSuspendResumeNotification and send events to the channel
+func NewEventListener(eventCh chan uint32) error {
+	const (
+		_DEVICE_NOTIFY_CALLBACK = 2
+	)
+	type _DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS struct {
+		callback uintptr
+		context  uintptr
+	}
+
+	// TODO: investgiate if this is safe to run in goroutines
+	var fn interface{} = func(context uintptr, changeType uint32, setting uintptr) uintptr {
+		eventCh <- changeType
+		return 0
+	}
+
+	params := _DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS{
+		callback: windows.NewCallback(fn),
+	}
+	handle := uintptr(0)
+	ret, _, err := powerRegisterSuspendResumeNotification.Call(
+		_DEVICE_NOTIFY_CALLBACK,
+		uintptr(unsafe.Pointer(&params)),
+		uintptr(unsafe.Pointer(&handle)),
+	)
+	if ret != 0 {
+		return err
+	}
+	return nil
+}

--- a/system/power/powercfg_test.go
+++ b/system/power/powercfg_test.go
@@ -1,4 +1,4 @@
-package thermal
+package power
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ func TestPersistPowerCfg(t *testing.T) {
 		OriginalName: "Name",
 	}
 
-	cfg := &PowerCfg{
+	cfg := &Cfg{
 		activePlan: expectedPlan,
 	}
 	require.NotEmpty(t, cfg.Name())
@@ -21,7 +21,7 @@ func TestPersistPowerCfg(t *testing.T) {
 	b := cfg.Value()
 	require.NotEmpty(t, b)
 
-	loaded := PowerCfg{}
+	loaded := Cfg{}
 
 	require.NoError(t, loaded.Load(b))
 	require.EqualValues(t, expectedPlan, loaded.activePlan)

--- a/system/thermal/thermal.go
+++ b/system/thermal/thermal.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/zllovesuki/G14Manager/system/atkacpi"
 	"github.com/zllovesuki/G14Manager/system/persist"
+	"github.com/zllovesuki/G14Manager/system/power"
 )
 
 const (
@@ -55,7 +56,7 @@ type Control struct {
 
 // Config defines the entry point for Windows Power Option and a list of thermal profiles
 type Config struct {
-	PowerCfg *PowerCfg
+	PowerCfg *power.Cfg
 	Profiles []Profile
 }
 

--- a/util/debounce.go
+++ b/util/debounce.go
@@ -41,3 +41,25 @@ func Debounce(haltCtx context.Context, wait time.Duration) (chan<- interface{}, 
 
 	return in, out
 }
+
+// PassThrough will pipe (dirty) input directly to (clean) output without debouncing.
+func PassThrough(haltCtx context.Context) (chan<- interface{}, <-chan DebounceEvent) {
+	in := make(chan interface{})
+	out := make(chan DebounceEvent, 1) // do not block our goroutine
+
+	go func() {
+		for {
+			select {
+			case data := <-in:
+				out <- DebounceEvent{
+					Counter: 1,
+					Data:    data,
+				}
+			case <-haltCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return in, out
+}


### PR DESCRIPTION
This fixes #42 by reapplying configurations on suspend resume. It also turns off keyboard backlight prior to suspend.

Controller will now be using workQueue instead of performing hardward IO on a different goroutine.